### PR TITLE
Add daily cron to portability workflow

### DIFF
--- a/.github/workflows/portability-tests.yml
+++ b/.github/workflows/portability-tests.yml
@@ -51,7 +51,7 @@ jobs:
               boost_ver=1.67.0
               vtk_ver=
               petsc_ver=3.9.4
-              hdf5_ver=1.10.2
+              hdf5_ver=1.10.3
               petsc_arch=linux-gnu
               ;;
             4)
@@ -62,7 +62,7 @@ jobs:
               boost_ver=1.71.0
               vtk_ver=8.1.0
               petsc_ver=3.11.3
-              hdf5_ver=1.10.3
+              hdf5_ver=1.10.4
               petsc_arch=linux-gnu
               ;;
             5)
@@ -73,7 +73,7 @@ jobs:
               boost_ver=1.73.0
               vtk_ver=8.2.0
               petsc_ver=3.12.4
-              hdf5_ver=1.10.4
+              hdf5_ver=1.10.5
               petsc_arch=linux-gnu
               ;;
             6)

--- a/.github/workflows/portability-tests.yml
+++ b/.github/workflows/portability-tests.yml
@@ -21,86 +21,88 @@ jobs:
           weekday=$(date +'%w')
           
           case ${weekday} in
-          1)
-            # Mon: Oldest on Ubuntu 18.04 LTS
-            xsd_ver=4.0.0
-            xercesc_ver=3.2.0
-            sundials_ver=2.7.0
-            boost_ver=1.62.0
-            vtk_ver=6.3.0
-            petsc_ver=3.7.7
-            hdf5_ver=1.10.0-patch1
-            petsc_arch=linux-gnu
-            ;;
-          2)
-            # Tue
-            xsd_ver=4.0.0
-            xercesc_ver=3.2.1
-            sundials_ver=3.1.2
-            boost_ver=1.66.0
-            vtk_ver=7.1.0
-            petsc_ver=3.8.4
-            hdf5_ver=1.10.1
-            petsc_arch=linux-gnu
-            ;;
-          3)
-            # Wed: Minimal config - no Sundials or VTK
-            xsd_ver=4.0.0
-            xercesc_ver=3.2.2
-            sundials_ver=
-            boost_ver=1.67.0
-            vtk_ver=
-            petsc_ver=3.9.4
-            hdf5_ver=1.10.2
-            petsc_arch=linux-gnu
-            ;;
-          4)
-            # Thu
-            xsd_ver=4.0.0
-            xercesc_ver=3.2.1
-            sundials_ver=4.1.0
-            boost_ver=1.71.0
-            vtk_ver=8.1.0
-            petsc_ver=3.11.3
-            hdf5_ver=1.10.3
-            petsc_arch=linux-gnu
-            ;;
-          5)
-            # Fri
-            xsd_ver=4.0.0
-            xercesc_ver=3.2.2
-            sundials_ver=5.1.0
-            boost_ver=1.73.0
-            vtk_ver=8.2.0
-            petsc_ver=3.12.4
-            hdf5_ver=1.10.4
-            petsc_arch=linux-gnu
-            ;;
-          6)
-            # Sat: Newest on Ubuntu 22.04 LTS
-            xsd_ver=4.0.0
-            xercesc_ver=3.2.3
-            sundials_ver=5.8.0
-            boost_ver=1.74.0
-            vtk_ver=9.1.0
-            petsc_ver=3.15.5
-            hdf5_ver=1.10.7
-            petsc_arch=linux-gnu
-            ;;
-          0)
-            # Sun: Bleeding Edge
-            xsd_ver=4.0.0
-            xercesc_ver=3.2.3
-            sundials_ver=6.3.0
-            boost_ver=1.80.0
-            vtk_ver=9.2.0
-            petsc_ver=3.17.4
-            hdf5_ver=1.12.2
-            petsc_arch=linux-gnu
-            ;;
-          *)
-            echo "Unknown weekday: ${weekday}"
-            exit 1
+            1)
+              # Mon: Oldest on Ubuntu 18.04 LTS
+              xsd_ver=4.0.0
+              xercesc_ver=3.2.0
+              sundials_ver=2.7.0
+              boost_ver=1.62.0
+              vtk_ver=6.3.0
+              petsc_ver=3.7.7
+              hdf5_ver=1.10.0-patch1
+              petsc_arch=linux-gnu
+              ;;
+            2)
+              # Tue
+              xsd_ver=4.0.0
+              xercesc_ver=3.2.1
+              sundials_ver=3.1.2
+              boost_ver=1.66.0
+              vtk_ver=7.1.0
+              petsc_ver=3.8.4
+              hdf5_ver=1.10.1
+              petsc_arch=linux-gnu
+              ;;
+            3)
+              # Wed: Minimal config - no Sundials or VTK
+              xsd_ver=4.0.0
+              xercesc_ver=3.2.2
+              sundials_ver=
+              boost_ver=1.67.0
+              vtk_ver=
+              petsc_ver=3.9.4
+              hdf5_ver=1.10.2
+              petsc_arch=linux-gnu
+              ;;
+            4)
+              # Thu
+              xsd_ver=4.0.0
+              xercesc_ver=3.2.1
+              sundials_ver=4.1.0
+              boost_ver=1.71.0
+              vtk_ver=8.1.0
+              petsc_ver=3.11.3
+              hdf5_ver=1.10.3
+              petsc_arch=linux-gnu
+              ;;
+            5)
+              # Fri
+              xsd_ver=4.0.0
+              xercesc_ver=3.2.2
+              sundials_ver=5.1.0
+              boost_ver=1.73.0
+              vtk_ver=8.2.0
+              petsc_ver=3.12.4
+              hdf5_ver=1.10.4
+              petsc_arch=linux-gnu
+              ;;
+            6)
+              # Sat: Newest on Ubuntu 22.04 LTS
+              xsd_ver=4.0.0
+              xercesc_ver=3.2.3
+              sundials_ver=5.8.0
+              boost_ver=1.74.0
+              vtk_ver=9.1.0
+              petsc_ver=3.15.5
+              hdf5_ver=1.10.7
+              petsc_arch=linux-gnu
+              ;;
+            0)
+              # Sun: Bleeding Edge
+              xsd_ver=4.0.0
+              xercesc_ver=3.2.3
+              sundials_ver=6.3.0
+              boost_ver=1.80.0
+              vtk_ver=9.2.0
+              petsc_ver=3.17.4
+              hdf5_ver=1.12.2
+              petsc_arch=linux-gnu
+              ;;
+            *)
+              echo "Unknown weekday: ${weekday}"
+              exit 1
+              ;;
+          esac
           
           echo "xsd_ver=${xsd_ver}" >> ${GITHUB_ENV}
           echo "xercesc_ver=${xercesc_ver}" >> ${GITHUB_ENV}

--- a/.github/workflows/portability-tests.yml
+++ b/.github/workflows/portability-tests.yml
@@ -87,7 +87,7 @@ jobs:
             hdf5_ver=1.10.7
             petsc_arch=linux-gnu
             ;;
-          7)
+          0)
             # Sun: Bleeding Edge
             xsd_ver=4.0.0
             xercesc_ver=3.2.3
@@ -315,17 +315,17 @@ jobs:
           cd Chaste/build
           nice -n ${{ env.NICE }} ctest -j ${{ env.NCPU }} -L Continuous --output-on-failure
 
-      - name: run parallel test pack
-        run: |
-          . ./modulesinit.sh
-          cd Chaste/build
-          nice -n ${{ env.NICE }} ctest -j ${{ env.NCPU }} -L Parallel --output-on-failure
-
       - name: run nightly test pack
         run: |
           . ./modulesinit.sh
           cd Chaste/build
           nice -n ${{ env.NICE }} ctest -j ${{ env.NCPU }} -L Nightly --output-on-failure
+
+      - name: run parallel test pack
+        run: |
+          . ./modulesinit.sh
+          cd Chaste/build
+          nice -n ${{ env.NICE }} ctest -j ${{ env.NCPU }} -L Parallel --output-on-failure
 
       - name: cleanup
         if: always()

--- a/.github/workflows/portability-tests.yml
+++ b/.github/workflows/portability-tests.yml
@@ -119,6 +119,8 @@ jobs:
           echo "CHASTE_TEST_OUTPUT=${HOME}/testoutput/$(date +'%Y%m%d%H%M%S')" >> ${GITHUB_ENV}
           
           echo "NCPU=$(( $(nproc) < 16 ? $(nproc) : 16 ))" >> ${GITHUB_ENV}
+          
+          echo "NICE=10" >> ${GITHUB_ENV}
 
       - name: make directories
         run: |
@@ -136,7 +138,7 @@ jobs:
           . ./modulesinit.sh
           err=0 && module test xsd/${{ env.xsd_ver }} || err=$?
           if [ $err -ne 0 ]; then
-            nice -n 10 install_xsd.sh \
+            nice -n ${{ env.NICE }} install_xsd.sh \
               --version=${{ env.xsd_ver }} \
               --modules-dir=${{ env.MODULES_DIR }}
             module test xsd/${{ env.xsd_ver }}
@@ -147,7 +149,7 @@ jobs:
           . ./modulesinit.sh
           err=0 && module test xercesc/${{ env.xercesc_ver }} || err=$?
           if [ $err -ne 0 ]; then
-            nice -n 10 install_xercesc.sh \
+            nice -n ${{ env.NICE }} install_xercesc.sh \
               --version=${{ env.xercesc_ver }} \
               --modules-dir=${{ env.MODULES_DIR }} \
               --parallel=${{ env.NCPU }}
@@ -160,7 +162,7 @@ jobs:
             . ./modulesinit.sh
             err=0 && module test sundials/${{ env.sundials_ver }} || err=$?
             if [ $err -ne 0 ]; then
-              nice -n 10 install_sundials.sh \
+              nice -n ${{ env.NICE }} install_sundials.sh \
                 --version=${{ env.sundials_ver }} \
                 --modules-dir=${{ env.MODULES_DIR }} \
                 --parallel=${{ env.NCPU }}
@@ -173,7 +175,7 @@ jobs:
           . ./modulesinit.sh
           err=0 && module test boost/${{ env.boost_ver }} || err=$?
           if [ $err -ne 0 ]; then
-            nice -n 10 install_boost.sh \
+            nice -n ${{ env.NICE }} install_boost.sh \
               --version=${{ env.boost_ver }} \
               --modules-dir=${{ env.MODULES_DIR }} \
               --parallel=${{ env.NCPU }}
@@ -186,7 +188,7 @@ jobs:
             . ./modulesinit.sh
             err=0 && module test vtk/${{ env.vtk_ver }} || err=$?
             if [ $err -ne 0 ]; then
-              nice -n 10 install_vtk.sh \
+              nice -n ${{ env.NICE }} install_vtk.sh \
                 --version=${{ env.vtk_ver }} \
                 --modules-dir=${{ env.MODULES_DIR }} \
                 --parallel=${{ env.NCPU }}
@@ -199,7 +201,7 @@ jobs:
           . ./modulesinit.sh
           err=0 && module test petsc_hdf5/${{ env.petsc_ver }}_${{ env.hdf5_ver }}/${{ env.petsc_arch }} || err=$?
           if [ $err -ne 0 ]; then
-            nice -n 10 install_petsc_hdf5.sh \
+            nice -n ${{ env.NICE }} install_petsc_hdf5.sh \
               --petsc-version=${{ env.petsc_ver }} \
               --hdf5-version=${{ env.hdf5_ver }} \
               --petsc-arch=${{ env.petsc_arch }} \
@@ -251,7 +253,7 @@ jobs:
 
           mkdir -p Chaste/build
           cd Chaste/build
-          nice -n 10 cmake \
+          nice -n ${{ env.NICE }} cmake \
             -DBoost_NO_BOOST_CMAKE=ON \
             -DBoost_NO_SYSTEM_PATHS=ON \
             -DBOOST_ROOT=${BOOST_ROOT} \
@@ -265,8 +267,8 @@ jobs:
         run: |
           . ./modulesinit.sh
           cd Chaste/build
-          nice -n 10 cmake --build . --parallel ${{ env.NCPU }} --target TestChasteBuildInfo
-          nice -n 10 ctest -V -R TestChasteBuildInfo --output-on-failure | tee buildinfo
+          nice -n ${{ env.NICE }} cmake --build . --parallel ${{ env.NCPU }} --target TestChasteBuildInfo
+          nice -n ${{ env.NICE }} ctest -V -R TestChasteBuildInfo --output-on-failure | tee buildinfo
 
       - name: verify dependency versions
         run: |
@@ -301,71 +303,29 @@ jobs:
           hdf5_ver="$(echo ${{ env.hdf5_ver }} | grep -o ${maj_min_rev})"
           grep "<HDF5>${hdf5_ver}</HDF5>" buildinfo
 
-      - name: build core libraries
+      - name: build all
         run: |
           . ./modulesinit.sh
           cd Chaste/build
-          nice -n 10 cmake --build . --parallel ${{ env.NCPU }} --target chaste_core
-
-      - name: build cell_based
-        run: |
-          . ./modulesinit.sh
-          cd Chaste/build
-          nice -n 10 cmake --build . --parallel ${{ env.NCPU }} --target chaste_cell_based
-
-      - name: build crypt
-        run: |
-          . ./modulesinit.sh
-          cd Chaste/build
-          nice -n 10 cmake --build . --parallel ${{ env.NCPU }} --target chaste_crypt
-
-      - name: build heart
-        run: |
-          . ./modulesinit.sh
-          cd Chaste/build
-          nice -n 10 cmake --build . --parallel ${{ env.NCPU }} --target chaste_heart
-
-      - name: build lung
-        run: |
-          . ./modulesinit.sh
-          cd Chaste/build
-          nice -n 10 cmake --build . --parallel ${{ env.NCPU }} --target chaste_lung
-
-      - name: build continuous test pack
-        run: |
-          . ./modulesinit.sh
-          cd Chaste/build
-          nice -n 10 cmake --build . --parallel ${{ env.NCPU }} --target Continuous
-
-      - name: build parallel test pack
-        run: |
-          . ./modulesinit.sh
-          cd Chaste/build
-          nice -n 10 cmake --build . --parallel ${{ env.NCPU }} --target Parallel
-
-      - name: build nightly test pack
-        run: |
-          . ./modulesinit.sh
-          cd Chaste/build
-          nice -n 10 cmake --build . --parallel ${{ env.NCPU }} --target Nightly
+          nice -n ${{ env.NICE }} cmake --build . --parallel ${{ env.NCPU }} --target all
 
       - name: run continuous test pack
         run: |
           . ./modulesinit.sh
           cd Chaste/build
-          nice -n 10 ctest -j ${{ env.NCPU }} -L Continuous --output-on-failure
+          nice -n ${{ env.NICE }} ctest -j ${{ env.NCPU }} -L Continuous --output-on-failure
 
       - name: run parallel test pack
         run: |
           . ./modulesinit.sh
           cd Chaste/build
-          nice -n 10 ctest -j ${{ env.NCPU }} -L Parallel --output-on-failure
+          nice -n ${{ env.NICE }} ctest -j ${{ env.NCPU }} -L Parallel --output-on-failure
 
       - name: run nightly test pack
         run: |
           . ./modulesinit.sh
           cd Chaste/build
-          nice -n 10 ctest -j ${{ env.NCPU }} -L Nightly --output-on-failure
+          nice -n ${{ env.NICE }} ctest -j ${{ env.NCPU }} -L Nightly --output-on-failure
 
       - name: cleanup
         if: always()

--- a/.github/workflows/portability-tests.yml
+++ b/.github/workflows/portability-tests.yml
@@ -2,49 +2,123 @@ name: portability-tests
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * *'
 
 jobs:
-  setup:
-    name: portability-tests
-
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-focal
-            xsd_ver: 4.0.0
-            xercesc_ver: 3.2.3
-            sundials_ver: 6.0.0
-            boost_ver: 1.74.0
-            vtk_ver: 9.1.0
-            petsc_ver: 3.12.4
-            hdf5_ver: 1.10.4
-            petsc_arch: linux-gnu
-
-          - os: ubuntu-focal
-            xsd_ver: 4.0.0
-            xercesc_ver: 3.2.0
-            sundials_ver: 4.1.0
-            boost_ver: 1.62.0
-            vtk_ver: 6.3.0
-            petsc_ver: 3.7.7
-            hdf5_ver: 1.10.0-patch1
-            petsc_arch: linux-gnu
-
-      fail-fast: false
-
-    runs-on: [self-hosted, '${{ matrix.os }}']
-
+  run-tests:
+    runs-on: [self-hosted, ubuntu-focal]
+    timeout-minutes: 360
+    
     defaults:
       run:
         # --login to source /etc/profile.d/modules.sh
         shell: bash --login -e -o pipefail {0}
-
+        
     steps:
+      - name: set versions by 
+      
+        run: |
+          weekday=$(date +'%w')
+          
+          case ${weekday} in
+          1)
+            # Mon: Oldest on Ubuntu 18.04 LTS
+            xsd_ver=4.0.0
+            xercesc_ver=3.2.0
+            sundials_ver=2.7.0
+            boost_ver=1.62.0
+            vtk_ver=6.3.0
+            petsc_ver=3.7.7
+            hdf5_ver=1.10.0-patch1
+            petsc_arch=linux-gnu
+            ;;
+          2)
+            # Tue
+            xsd_ver=4.0.0
+            xercesc_ver=3.2.1
+            sundials_ver=3.1.2
+            boost_ver=1.66.0
+            vtk_ver=7.1.0
+            petsc_ver=3.8.4
+            hdf5_ver=1.10.1
+            petsc_arch=linux-gnu
+            ;;
+          3)
+            # Wed: Minimal config - no Sundials or VTK
+            xsd_ver=4.0.0
+            xercesc_ver=3.2.2
+            sundials_ver=
+            boost_ver=1.67.0
+            vtk_ver=
+            petsc_ver=3.9.4
+            hdf5_ver=1.10.2
+            petsc_arch=linux-gnu
+            ;;
+          4)
+            # Thu
+            xsd_ver=4.0.0
+            xercesc_ver=3.2.1
+            sundials_ver=4.1.0
+            boost_ver=1.71.0
+            vtk_ver=8.1.0
+            petsc_ver=3.11.3
+            hdf5_ver=1.10.3
+            petsc_arch=linux-gnu
+            ;;
+          5)
+            # Fri
+            xsd_ver=4.0.0
+            xercesc_ver=3.2.2
+            sundials_ver=5.1.0
+            boost_ver=1.73.0
+            vtk_ver=8.2.0
+            petsc_ver=3.12.4
+            hdf5_ver=1.10.4
+            petsc_arch=linux-gnu
+            ;;
+          6)
+            # Sat: Newest on Ubuntu 22.04 LTS
+            xsd_ver=4.0.0
+            xercesc_ver=3.2.3
+            sundials_ver=5.8.0
+            boost_ver=1.74.0
+            vtk_ver=9.1.0
+            petsc_ver=3.15.5
+            hdf5_ver=1.10.7
+            petsc_arch=linux-gnu
+            ;;
+          7)
+            # Sun: Bleeding Edge
+            xsd_ver=4.0.0
+            xercesc_ver=3.2.3
+            sundials_ver=6.3.0
+            boost_ver=1.80.0
+            vtk_ver=9.2.0
+            petsc_ver=3.17.4
+            hdf5_ver=1.12.2
+            petsc_arch=linux-gnu
+            ;;
+          *)
+            echo "Unknown weekday: ${weekday}"
+            exit 1
+          
+          echo "xsd_ver=${xsd_ver}" >> ${GITHUB_ENV}
+          echo "xercesc_ver=${xercesc_ver}" >> ${GITHUB_ENV}
+          echo "sundials_ver=${sundials_ver}" >> ${GITHUB_ENV}
+          echo "boost_ver=${boost_ver}" >> ${GITHUB_ENV}
+          echo "vtk_ver=${vtk_ver}" >> ${GITHUB_ENV}
+          echo "petsc_ver=${petsc_ver}" >> ${GITHUB_ENV}
+          echo "hdf5_ver=${hdf5_ver}" >> ${GITHUB_ENV}
+          echo "petsc_arch=${petsc_arch}" >> ${GITHUB_ENV}
+
       - name: set env variables
         run: |
-          modules_dir="${MODULES_DIR:-${HOME}/modules}"
-          echo "MODULES_DIR=${modules_dir}" >> ${GITHUB_ENV}
+          MODULES_DIR="${MODULES_DIR:-${HOME}/modules}"
+          echo "MODULES_DIR=${MODULES_DIR}" >> ${GITHUB_ENV}
+          
           echo "CHASTE_TEST_OUTPUT=${HOME}/testoutput/$(date +'%Y%m%d%H%M%S')" >> ${GITHUB_ENV}
+          
           echo "NCPU=$(( $(nproc) < 16 ? $(nproc) : 16 ))" >> ${GITHUB_ENV}
 
       - name: make directories
@@ -61,84 +135,84 @@ jobs:
       - name: setup xsd
         run: |
           . ./modulesinit.sh
-          err=0 && module test xsd/${{ matrix.xsd_ver }} || err=$?
+          err=0 && module test xsd/${{ env.xsd_ver }} || err=$?
           if [ $err -ne 0 ]; then
             nice -n 10 install_xsd.sh \
-              --version=${{ matrix.xsd_ver }} \
+              --version=${{ env.xsd_ver }} \
               --modules-dir=${{ env.MODULES_DIR }}
-            module test xsd/${{ matrix.xsd_ver }}
+            module test xsd/${{ env.xsd_ver }}
           fi
 
       - name: setup xercesc
         run: |
           . ./modulesinit.sh
-          err=0 && module test xercesc/${{ matrix.xercesc_ver }} || err=$?
+          err=0 && module test xercesc/${{ env.xercesc_ver }} || err=$?
           if [ $err -ne 0 ]; then
             nice -n 10 install_xercesc.sh \
-              --version=${{ matrix.xercesc_ver }} \
+              --version=${{ env.xercesc_ver }} \
               --modules-dir=${{ env.MODULES_DIR }} \
               --parallel=${{ env.NCPU }}
-            module test xercesc/${{ matrix.xercesc_ver }}
+            module test xercesc/${{ env.xercesc_ver }}
           fi
 
       - name: setup sundials
         run: |
           . ./modulesinit.sh
-          err=0 && module test sundials/${{ matrix.sundials_ver }} || err=$?
+          err=0 && module test sundials/${{ env.sundials_ver }} || err=$?
           if [ $err -ne 0 ]; then
             nice -n 10 install_sundials.sh \
-              --version=${{ matrix.sundials_ver }} \
+              --version=${{ env.sundials_ver }} \
               --modules-dir=${{ env.MODULES_DIR }} \
               --parallel=${{ env.NCPU }}
-            module test sundials/${{ matrix.sundials_ver }}
+            module test sundials/${{ env.sundials_ver }}
           fi
 
       - name: setup boost
         run: |
           . ./modulesinit.sh
-          err=0 && module test boost/${{ matrix.boost_ver }} || err=$?
+          err=0 && module test boost/${{ env.boost_ver }} || err=$?
           if [ $err -ne 0 ]; then
             nice -n 10 install_boost.sh \
-              --version=${{ matrix.boost_ver }} \
+              --version=${{ env.boost_ver }} \
               --modules-dir=${{ env.MODULES_DIR }} \
               --parallel=${{ env.NCPU }}
-            module test boost/${{ matrix.boost_ver }}
+            module test boost/${{ env.boost_ver }}
           fi
 
       - name: setup vtk
         run: |
           . ./modulesinit.sh
-          err=0 && module test vtk/${{ matrix.vtk_ver }} || err=$?
+          err=0 && module test vtk/${{ env.vtk_ver }} || err=$?
           if [ $err -ne 0 ]; then
             nice -n 10 install_vtk.sh \
-              --version=${{ matrix.vtk_ver }} \
+              --version=${{ env.vtk_ver }} \
               --modules-dir=${{ env.MODULES_DIR }} \
               --parallel=${{ env.NCPU }}
-            module test vtk/${{ matrix.vtk_ver }}
+            module test vtk/${{ env.vtk_ver }}
           fi
 
       - name: setup petsc_hdf5
         run: |
           . ./modulesinit.sh
-          err=0 && module test petsc_hdf5/${{ matrix.petsc_ver }}_${{ matrix.hdf5_ver }}/${{ matrix.petsc_arch }} || err=$?
+          err=0 && module test petsc_hdf5/${{ env.petsc_ver }}_${{ env.hdf5_ver }}/${{ env.petsc_arch }} || err=$?
           if [ $err -ne 0 ]; then
             nice -n 10 install_petsc_hdf5.sh \
-              --petsc-version=${{ matrix.petsc_ver }} \
-              --hdf5-version=${{ matrix.hdf5_ver }} \
-              --petsc-arch=${{ matrix.petsc_arch }} \
+              --petsc-version=${{ env.petsc_ver }} \
+              --hdf5-version=${{ env.hdf5_ver }} \
+              --petsc-arch=${{ env.petsc_arch }} \
               --modules-dir=${{ env.MODULES_DIR }} \
               --parallel=${{ env.NCPU }}
-            module test petsc_hdf5/${{ matrix.petsc_ver }}_${{ matrix.hdf5_ver }}/${{ matrix.petsc_arch }}
+            module test petsc_hdf5/${{ env.petsc_ver }}_${{ env.hdf5_ver }}/${{ env.petsc_arch }}
           fi
 
       - name: add versions to modules init script
         run: |
-          echo "module load xsd/${{ matrix.xsd_ver }}" >> modulesinit.sh
-          echo "module load xercesc/${{ matrix.xercesc_ver }}" >> modulesinit.sh
-          echo "module load sundials/${{ matrix.sundials_ver }}" >> modulesinit.sh
-          echo "module load boost/${{ matrix.boost_ver }}" >> modulesinit.sh
-          echo "module load vtk/${{ matrix.vtk_ver }}" >> modulesinit.sh
-          echo "module load petsc_hdf5/${{ matrix.petsc_ver }}_${{ matrix.hdf5_ver }}/${{ matrix.petsc_arch }}" >> modulesinit.sh
+          echo "module load xsd/${{ env.xsd_ver }}" >> modulesinit.sh
+          echo "module load xercesc/${{ env.xercesc_ver }}" >> modulesinit.sh
+          echo "module load sundials/${{ env.sundials_ver }}" >> modulesinit.sh
+          echo "module load boost/${{ env.boost_ver }}" >> modulesinit.sh
+          echo "module load vtk/${{ env.vtk_ver }}" >> modulesinit.sh
+          echo "module load petsc_hdf5/${{ env.petsc_ver }}_${{ env.hdf5_ver }}/${{ env.petsc_arch }}" >> modulesinit.sh
 
       - name: checkout chaste
         uses: actions/checkout@v3
@@ -175,13 +249,13 @@ jobs:
           maj_min_rev='^[0-9]\+\.[0-9]\+\.[0-9]\+'
           maj_min='^[0-9]\+\.[0-9]\+'
 
-          xsd_ver="$(echo ${{ matrix.xsd_ver }} | grep -o ${maj_min_rev})"
-          xercesc_ver="$(echo ${{ matrix.xercesc_ver }} | grep -o ${maj_min_rev})"
-          sundials_ver="$(echo ${{ matrix.sundials_ver }} | grep -o ${maj_min_rev})"
-          boost_ver="$(echo ${{ matrix.boost_ver }} | grep -o ${maj_min_rev})"
-          vtk_ver="$(echo ${{ matrix.vtk_ver }} | grep -o ${maj_min})"
-          petsc_ver="$(echo ${{ matrix.petsc_ver }} | grep -o ${maj_min_rev})"
-          hdf5_ver="$(echo ${{ matrix.hdf5_ver }} | grep -o ${maj_min_rev})"
+          xsd_ver="$(echo ${{ env.xsd_ver }} | grep -o ${maj_min_rev})"
+          xercesc_ver="$(echo ${{ env.xercesc_ver }} | grep -o ${maj_min_rev})"
+          sundials_ver="$(echo ${{ env.sundials_ver }} | grep -o ${maj_min_rev})"
+          boost_ver="$(echo ${{ env.boost_ver }} | grep -o ${maj_min_rev})"
+          vtk_ver="$(echo ${{ env.vtk_ver }} | grep -o ${maj_min})"
+          petsc_ver="$(echo ${{ env.petsc_ver }} | grep -o ${maj_min_rev})"
+          hdf5_ver="$(echo ${{ env.hdf5_ver }} | grep -o ${maj_min_rev})"
 
           grep "<XSD>${xsd_ver}</XSD>" buildinfo
           grep "<Xerces>${xercesc_ver}</Xerces>" buildinfo

--- a/.github/workflows/portability-tests.yml
+++ b/.github/workflows/portability-tests.yml
@@ -16,8 +16,7 @@ jobs:
         shell: bash --login -e -o pipefail {0}
         
     steps:
-      - name: set versions by 
-      
+      - name: set versions by weekday
         run: |
           weekday=$(date +'%w')
           
@@ -157,14 +156,16 @@ jobs:
 
       - name: setup sundials
         run: |
-          . ./modulesinit.sh
-          err=0 && module test sundials/${{ env.sundials_ver }} || err=$?
-          if [ $err -ne 0 ]; then
-            nice -n 10 install_sundials.sh \
-              --version=${{ env.sundials_ver }} \
-              --modules-dir=${{ env.MODULES_DIR }} \
-              --parallel=${{ env.NCPU }}
-            module test sundials/${{ env.sundials_ver }}
+          if [ -n "${{ env.sundials_ver }}" ]; then
+            . ./modulesinit.sh
+            err=0 && module test sundials/${{ env.sundials_ver }} || err=$?
+            if [ $err -ne 0 ]; then
+              nice -n 10 install_sundials.sh \
+                --version=${{ env.sundials_ver }} \
+                --modules-dir=${{ env.MODULES_DIR }} \
+                --parallel=${{ env.NCPU }}
+              module test sundials/${{ env.sundials_ver }}
+            fi
           fi
 
       - name: setup boost
@@ -181,14 +182,16 @@ jobs:
 
       - name: setup vtk
         run: |
-          . ./modulesinit.sh
-          err=0 && module test vtk/${{ env.vtk_ver }} || err=$?
-          if [ $err -ne 0 ]; then
-            nice -n 10 install_vtk.sh \
-              --version=${{ env.vtk_ver }} \
-              --modules-dir=${{ env.MODULES_DIR }} \
-              --parallel=${{ env.NCPU }}
-            module test vtk/${{ env.vtk_ver }}
+          if [ -n "${{ env.vtk_ver }}" ]; then
+            . ./modulesinit.sh
+            err=0 && module test vtk/${{ env.vtk_ver }} || err=$?
+            if [ $err -ne 0 ]; then
+              nice -n 10 install_vtk.sh \
+                --version=${{ env.vtk_ver }} \
+                --modules-dir=${{ env.MODULES_DIR }} \
+                --parallel=${{ env.NCPU }}
+              module test vtk/${{ env.vtk_ver }}
+            fi
           fi
 
       - name: setup petsc_hdf5
@@ -208,10 +211,19 @@ jobs:
       - name: add versions to modules init script
         run: |
           echo "module load xsd/${{ env.xsd_ver }}" >> modulesinit.sh
+          
           echo "module load xercesc/${{ env.xercesc_ver }}" >> modulesinit.sh
-          echo "module load sundials/${{ env.sundials_ver }}" >> modulesinit.sh
+          
+          if [ -n "${{ env.sundials_ver }}" ]; then
+            echo "module load sundials/${{ env.sundials_ver }}" >> modulesinit.sh
+          fi
+          
           echo "module load boost/${{ env.boost_ver }}" >> modulesinit.sh
-          echo "module load vtk/${{ env.vtk_ver }}" >> modulesinit.sh
+          
+          if [ -n "${{ env.vtk_ver }}" ]; then
+            echo "module load vtk/${{ env.vtk_ver }}" >> modulesinit.sh
+          fi
+          
           echo "module load petsc_hdf5/${{ env.petsc_ver }}_${{ env.hdf5_ver }}/${{ env.petsc_arch }}" >> modulesinit.sh
 
       - name: checkout chaste
@@ -224,13 +236,28 @@ jobs:
       - name: configure chaste
         run: |
           . ./modulesinit.sh
+          
+          if [ -z "${{ env.sundials_ver }}" ]; then
+            use_cvode="OFF"
+          else
+            use_cvode="ON"
+          fi
+          
+          if [ -z "${{ env.vtk_ver }}" ]; then
+            use_vtk="OFF"
+          else
+            use_vtk="ON"
+          fi
+
           mkdir -p Chaste/build
           cd Chaste/build
           nice -n 10 cmake \
             -DBoost_NO_BOOST_CMAKE=ON \
             -DBoost_NO_SYSTEM_PATHS=ON \
             -DBOOST_ROOT=${BOOST_ROOT} \
-            -DCMAKE_PREFIX_PATH="${SUNDIALS_ROOT};${VTK_ROOT};${XERCESC_ROOT};${XSD_ROOT}" \
+            -DChaste_USE_CVODE=${use_cvode} \
+            -DChaste_USE_VTK=${use_vtk} \
+            -DCMAKE_PREFIX_PATH="${XERCESC_ROOT};${XSD_ROOT};${SUNDIALS_ROOT};${VTK_ROOT}" \
             -DCMAKE_BUILD_TYPE=Release \
             ..
 
@@ -250,19 +277,28 @@ jobs:
           maj_min='^[0-9]\+\.[0-9]\+'
 
           xsd_ver="$(echo ${{ env.xsd_ver }} | grep -o ${maj_min_rev})"
-          xercesc_ver="$(echo ${{ env.xercesc_ver }} | grep -o ${maj_min_rev})"
-          sundials_ver="$(echo ${{ env.sundials_ver }} | grep -o ${maj_min_rev})"
-          boost_ver="$(echo ${{ env.boost_ver }} | grep -o ${maj_min_rev})"
-          vtk_ver="$(echo ${{ env.vtk_ver }} | grep -o ${maj_min})"
-          petsc_ver="$(echo ${{ env.petsc_ver }} | grep -o ${maj_min_rev})"
-          hdf5_ver="$(echo ${{ env.hdf5_ver }} | grep -o ${maj_min_rev})"
-
           grep "<XSD>${xsd_ver}</XSD>" buildinfo
+          
+          xercesc_ver="$(echo ${{ env.xercesc_ver }} | grep -o ${maj_min_rev})"
           grep "<Xerces>${xercesc_ver}</Xerces>" buildinfo
-          grep "<SUNDIALS>${sundials_ver}</SUNDIALS>" buildinfo
+          
+          if [ -n "${{ env.sundials_ver }}" ]; then
+            sundials_ver="$(echo ${{ env.sundials_ver }} | grep -o ${maj_min_rev})"
+            grep "<SUNDIALS>${sundials_ver}</SUNDIALS>" buildinfo
+          fi
+          
+          boost_ver="$(echo ${{ env.boost_ver }} | grep -o ${maj_min_rev})"
           grep "<Boost>${boost_ver}</Boost>" buildinfo
-          grep "<VTK>${vtk_ver}</VTK>" buildinfo
+          
+          if [ -n "${{ env.vtk_ver }}" ]; then
+            vtk_ver="$(echo ${{ env.vtk_ver }} | grep -o ${maj_min})"
+            grep "<VTK>${vtk_ver}</VTK>" buildinfo
+          fi
+          
+          petsc_ver="$(echo ${{ env.petsc_ver }} | grep -o ${maj_min_rev})"
           grep "<PETSc>${petsc_ver}</PETSc>" buildinfo
+          
+          hdf5_ver="$(echo ${{ env.hdf5_ver }} | grep -o ${maj_min_rev})"
           grep "<HDF5>${hdf5_ver}</HDF5>" buildinfo
 
       - name: build core libraries


### PR DESCRIPTION
# Description
This adds a daily schedule to the  [portability workflow](https://github.com/Chaste/dependency-modules/blob/portability_clone/.github/workflows/portability-tests.yml) with different versions of Chaste dependencies.

## Ubuntu versions
Oldest and newest versions of dependencies on Ubuntu LTS + bleeding edge versions.

. | Old | Bionic 18.04 | Focal 20.04 | Jammy 22.04 | New | Bleeding Edge [a]
:--: | :--: | :--: | :--: | :--: | :--: | :--:
XSD | 4.0.0 | 4.0.0 | 4.0.0 | 4.0.0 | 4.0.0 | 4.0.0
Xerces | 3.2.0 | 3.2.0 | 3.2.2 | 3.2.3 | 3.2.3 | 3.2.3
SUNDIALS | 2.7.0 | 2.7.0 | 3.1.2 | 5.8.0 | 5.8.0 | 6.3.0
Boost | 1.62.0 | 1.62 / 1.65 [b] | 1.67 / 1.71 | 1.74 | 1.74.0 | 1.80.0
VTK | 6.3.0 | 6.3 / 7.1 | 6.3 / 7.1 | 7.1 / 9.1 | 9.1 | 9.2.0
PETSc | 3.7.7 | 3.7.7 | 3.12.4 | 3.15.5 | 3.15.5 | 3.17.4
HDF5 | 1.10.0 | 1.10.0 | 1.10.4 | 1.10.7 | 1.10.7 | 1.12.2

[a] Updated 31 Aug 2022
[b] Boost 1.64 and 1.65 not [officially supported](https://chaste.cs.ox.ac.uk/trac/wiki/InstallGuides/DependencyVersions#Dependencies)

## Workflow versions
Dependency versions added to the [portability workflow](https://github.com/Chaste/dependency-modules/blob/portability_clone/.github/workflows/portability-tests.yml).

. | Mon (Old) | Tue | Wed (Minimal) | Thu | Fri | Sat (New) | Sun (B. Edge)
:--: | :--: | :--: | :--: | :--: | :--: | :--: | :--:
XSD | 4.0.0 | 4.0.0 | 4.0.0 | 4.0.0 | 4.0.0 | 4.0.0 | 4.0.0
Xerces | 3.2.0 | 3.2.1 | 3.2.2 | 3.2.1 | 3.2.2 | 3.2.3 | 3.2.3
SUNDIALS | 2.7.0 | 3.1.2 | - | 4.1.0 | 5.1.0 | 5.8.0 | 6.3.0
Boost | 1.62.0 | 1.66.0 | 1.67.0 | 1.71.0 | 1.73.0 | 1.74.0 | 1.80.0
VTK | 6.3.0 | 7.1.0 | - | 8.1.0 | 8.2.0 | 9.1.0 | 9.2.0
PETSc | 3.7.7 | 3.8.4 | 3.9.4 | 3.11.3 | 3.12.4 | 3.15.5 | 3.17.4
HDF5 | 1.10.0 | 1.10.1 | 1.10.3 | 1.10.4 | 1.10.5 | 1.10.7 | 1.12.2

## Buildbot versions
Current buildbot versions [c].

. | Mon | Tue | Wed | Thu | Fri | Sat | Sun
:--: | :--: | :--: | :--: | :--: | :--: | :--: | :--:
XSD | 4.0.0 | 4.0.0 | 4.0.0 | 4.0.0 | 4.0.0 | 4.0.0 | 4.0.0
Xerces | 3.1.3 | 3.2.0 | 3.1.4 | 3.2.1 | 3.2.1 | 3.2.2 | 3.2.2
SUNDIALS [d] | 2.5 <br>(cvode 2.7) | 2.7 <br>(cvode 2.9) | - | 3.1 | 4.1 | 2.5 <br>(cvode 2.7) | 2.7 <br>(cvode 2.9)
Boost | 1.58 | 1.65 | 1.66 | 1.72 | 1.73 | 1.71 | 1.74
VTK | 6.2 | 6.3 | - | 6.2 | 8.2 | 9.0 | 8.1
PETSc | 3.6.4 | 3.7.7 | 3.8.4 | 3.9.4 | 3.11.3 | 3.12.4 | 3.11.1
HDF5 | 1.8.16 | 1.10.0 | 1.8.21 | 1.10.3 | 1.10.5 | 1.10.4 | 1.10.5

[c] Updated 31 Aug 2022
[d] From 3.0.0 upwards, sundials version == cvode version


