### PR TITLE
Portability image builds

### DIFF
--- a/.github/workflows/docker-portability.yml
+++ b/.github/workflows/docker-portability.yml
@@ -1,0 +1,74 @@
+name: docker-portability
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tag: chaste/runner:jammy.portability01
+            build-args: |
+              BASE: jammy
+              XSD: 4.0.0
+              XERCESC: 3.2.0
+              SUNDIALS: 2.7.0
+              BOOST: 1.62.0
+              VTK: 6.3.0
+              PETSC: 3.7.7
+              HDF5: 1.10.0-patch1
+
+          - tag: chaste/runner:jammy.portability07
+            build-args: |
+              BASE: jammy
+              XSD: 4.0.0
+              XERCESC: 3.2.4
+              SUNDIALS: 6.5.0
+              BOOST: 1.81.0
+              VTK: 9.2.6
+              PETSC: 3.18.5
+              HDF5: 1.12.2
+            
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and export to Docker
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          pull: true
+          load: true
+          tags: ${{ matrix.tag }}
+          build-args: ${{ matrix.build-args }}
+            
+      - name: Test image
+        run: |
+          docker run --rm --entrypoint /bin/bash ${{ matrix.tag }}
+          
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          pull: true
+          push: true
+          tags: ${{ matrix.tag }}
+          build-args: ${{ matrix.build-args }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,14 @@ ARG BASE=focal
 
 FROM ubuntu:${BASE}
 
+ARG XSD=4.0.0
+ARG XERCESC=3.2.3
+ARG SUNDIALS=5.8.0
+ARG BOOST=1.73.0
+ARG VTK=7.1.1
+ARG PETSC=3.8.4
+ARG HDF5=1.10.8
+
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 
 USER root
@@ -40,28 +48,28 @@ RUN useradd -r -m -d ${DEFAULT_HOME} -s /bin/bash ${DEFAULT_USER} && \
     mkdir -p ${MODULES_DIR}/opt && \
     mkdir -p ${MODULES_DIR}/modulefiles && \
     install_xsd.sh \
-        --version=4.0.0 \
+        --version=${XSD} \
         --modules-dir=${MODULES_DIR} && \
     install_xercesc.sh \
-        --version=3.2.3 \
+        --version=${XERCESC} \
         --parallel=$(nproc) \
         --modules-dir=${MODULES_DIR} && \
     install_sundials.sh \
-        --version=5.8.0 \
+        --version=${SUNDIALS} \
         --parallel=$(nproc) \
         --modules-dir=${MODULES_DIR} && \
     install_boost.sh \
-        --version=1.73.0 \
+        --version=${BOOST} \
         --parallel=$(nproc) \
         --modules-dir=${MODULES_DIR} && \
     install_vtk.sh \
-        --version=7.1.1 \
+        --version=${VTK} \
         --parallel=$(nproc) \
         --modules-dir=${MODULES_DIR} && \
     install_petsc_hdf5.sh \
-        --petsc-version=3.8.4 \
+        --petsc-version=${PETSC} \
         --petsc-arch=linux-gnu \
-        --hdf5-version=1.10.8 \
+        --hdf5-version=${HDF5} \
         --parallel=$(nproc) \
         --modules-dir=${MODULES_DIR} && \
     echo "module use ${MODULES_DIR}/modulefiles" >> ${DEFAULT_HOME}/.bashrc && \


### PR DESCRIPTION
- Adds workflow for building chaste/runner images with specific dependency versions
- Tags will be in the format chaste/runner:jammy.portability01, chaste/runner:jammy.portability02 etc.