### PR TITLE
Bump hdf5 to 1.12 in portability-dev

### DIFF
--- a/.github/workflows/docker-portability-dev.yml
+++ b/.github/workflows/docker-portability-dev.yml
@@ -21,7 +21,7 @@ jobs:
               BOOST=1.74.0
               VTK=9.2.6
               PETSC=3.15.5
-              HDF5=1.10.8
+              HDF5=1.12.2
             
     steps:
       - name: Checkout


### PR DESCRIPTION
**Related Issues**
* https://github.com/Chaste/Chaste/issues/163