### PR TITLE
Add image-test workflows

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -6,6 +6,60 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tags: |
+              chaste/runner:test
+            build-args: |
+              BASE=jammy
+              XSD=4.0.0
+              XERCESC=3.2.4
+              SUNDIALS=5.8.0
+              BOOST=1.74.0
+              VTK=9.1.0
+              PETSC=3.15.5
+              HDF5=1.10.8
+            
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
-  steps:
-      uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and export to Docker
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          pull: true
+          load: true
+          tags: ${{ matrix.tags }}
+          build-args: ${{ matrix.build-args }}
+            
+      - name: Test image
+        run: |
+          tags=( ${{ matrix.tags }} )
+          for tag in "${tags[@]}"; do
+            docker run --rm --entrypoint /bin/bash ${tag}
+          done
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          pull: true
+          push: true
+          tags: ${{ matrix.tags }}
+          build-args: ${{ matrix.build-args }}

--- a/.github/workflows/image-tests.yml
+++ b/.github/workflows/image-tests.yml
@@ -2,10 +2,111 @@ name: image-tests
 
 on:
   workflow_dispatch:
+    inputs:
+      chaste_branch:
+        description: 'Chaste branch'
+        required: true
+        type: string
+        default: 'develop'
+
+      image_tag:
+        description: 'Runner image tag'
+        required: true
+        type: string
+        default: 'test'
 
 jobs:
-  docker:
+  build-and-test:
+
     runs-on: ubuntu-latest
 
-  steps:
-      uses: actions/checkout@v3
+    container:
+      image: "chaste/runner:${{ github.event.inputs.image_tag }}"
+      env:
+        RUNNER_OFF: 1
+      volumes:
+        - runner_volume:/home/runner
+      options: --user 0 --cpus 2
+
+    env:
+      CC: gcc
+      CXX: g++
+
+    defaults:
+      run:
+        shell: bash
+        
+    steps:
+      - name: compiler version
+        run: ${CXX} --version
+
+      - name: checkout chaste
+        uses: actions/checkout@v3
+        with:
+          repository: Chaste/Chaste
+          path: Chaste
+          ref: ${{ github.event.inputs.chaste_branch }}
+          
+      - name: make build and test directories
+        run: |
+          mkdir -p chaste-build-dir
+          mkdir -p chaste-test-dir
+          echo "CHASTE_TEST_OUTPUT=$(pwd)/chaste-test-dir" >> ${GITHUB_ENV}
+
+      - name: create module init script
+        run: |
+          echo "source /etc/profile.d/modules.sh" > init.sh
+          echo "module use /home/runner/modules/modulefiles" >> init.sh
+          echo "module purge" >> init.sh
+          echo "module load boost" >> init.sh
+          echo "module load petsc_hdf5" >> init.sh
+          echo "module load sundials" >> init.sh
+          echo "module load vtk" >> init.sh
+          echo "module load xercesc" >> init.sh
+          echo "module load xsd" >> init.sh
+        working-directory: chaste-build-dir
+
+      - name: set runner user privileges
+        run: chown -R runner:runner .
+          
+      - name: cmake configure
+        run: |
+          source init.sh
+          su -m runner -c "cmake \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DBoost_NO_SYSTEM_PATHS=ON \
+            -DBOOST_ROOT=${BOOST_ROOT} \
+            -DCMAKE_BUILD_TYPE=Release \
+            ../Chaste"
+        working-directory: chaste-build-dir
+
+      - name: compile build info
+        run: |
+          source init.sh
+          su -m runner -c "cmake --build . --target TestChasteBuildInfo --parallel $(nproc)"
+          su -m runner -c "ctest -V -R TestChasteBuildInfo --output-on-failure"
+        working-directory: chaste-build-dir
+
+      - name: build continuous test pack
+        run: |
+          source init.sh
+          su -m runner -c "cmake --build . --target Continuous --parallel $(nproc)"
+        working-directory: chaste-build-dir
+
+      - name: build nightly test pack
+        run: |
+          source init.sh
+          su -m runner -c "cmake --build . --target Nightly --parallel $(nproc)"
+        working-directory: chaste-build-dir
+
+      - name: run continuous test pack
+        run: |
+          source init.sh
+          su -m runner -c "ctest -j $(nproc) -L Continuous --output-on-failure"
+        working-directory: chaste-build-dir
+
+      - name: run nightly test pack
+        run: |
+          source init.sh
+          su -m runner -c "ctest -j $(nproc) -L Nightly --output-on-failure"
+        working-directory: chaste-build-dir


### PR DESCRIPTION
**Summary**
* Worflows for pushing a `chaste/runner:test` image to DockerHub and running portability tests.
* Useful for testing significant changes to main `Dockerfile`.