### PR TITLE
Boost config for system images

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -16,12 +16,12 @@ jobs:
             build-args: |
               BASE=jammy
               XSD=4.0.0
-              XERCESC=3.2.4
-              SUNDIALS=5.8.0
-              BOOST=1.74.0
-              VTK=9.1.0
-              PETSC=3.15.5
-              HDF5=1.10.8
+              XERCESC=3.2.2
+              SUNDIALS=3.1.2
+              BOOST=1.67.0
+              VTK=6.3.0
+              PETSC=3.12.4
+              HDF5=1.10.4
             
     steps:
       - name: Checkout

--- a/.github/workflows/image-tests.yml
+++ b/.github/workflows/image-tests.yml
@@ -72,12 +72,7 @@ jobs:
       - name: cmake configure
         run: |
           source init.sh
-          su -m runner -c "cmake \
-            -DBoost_NO_BOOST_CMAKE=ON \
-            -DBoost_NO_SYSTEM_PATHS=ON \
-            -DBOOST_ROOT=${BOOST_ROOT} \
-            -DCMAKE_BUILD_TYPE=Release \
-            ../Chaste"
+          su -m runner -c "cmake -DCMAKE_BUILD_TYPE=Release ../Chaste"
         working-directory: chaste-build-dir
 
       - name: compile build info

--- a/.github/workflows/ubuntu-tests.yml
+++ b/.github/workflows/ubuntu-tests.yml
@@ -96,13 +96,7 @@ jobs:
           module load vtk/${{ matrix.vtk_ver }}
           module load petsc_hdf5/${{ matrix.petsc_ver }}_${{ matrix.hdf5_ver }}/${{ matrix.petsc_arch }}
 
-          cmake \
-            -DBoost_NO_BOOST_CMAKE=ON \
-            -DBoost_NO_SYSTEM_PATHS=ON \
-            -DBOOST_ROOT=${BOOST_ROOT} \
-            -DCMAKE_PREFIX_PATH="${SUNDIALS_ROOT};${VTK_ROOT};${XERCESC_ROOT};${XSD_ROOT}" \
-            -DCMAKE_BUILD_TYPE=Release \
-            ..
+          cmake -DCMAKE_BUILD_TYPE=Release ..
 
           cmake --build . --parallel $(nproc) --target TestChasteBuildInfo
 

--- a/.github/workflows/version-tests.yml
+++ b/.github/workflows/version-tests.yml
@@ -231,12 +231,8 @@ jobs:
           mkdir -p Chaste/build
           cd Chaste/build
           nice -n ${{ env.niceness }} cmake \
-            -DBoost_NO_BOOST_CMAKE=ON \
-            -DBoost_NO_SYSTEM_PATHS=ON \
-            -DBOOST_ROOT=${BOOST_ROOT} \
             -DChaste_USE_CVODE=${use_cvode} \
             -DChaste_USE_VTK=${use_vtk} \
-            -DCMAKE_PREFIX_PATH="${XERCESC_ROOT};${XSD_ROOT};${SUNDIALS_ROOT};${VTK_ROOT}" \
             -DCMAKE_BUILD_TYPE=Release \
             ..
 

--- a/scripts/install_boost.sh
+++ b/scripts/install_boost.sh
@@ -69,6 +69,9 @@ setenv          BOOST_ROOT           /usr
 setenv          BOOST_INCLUDEDIR     /usr/include/boost
 setenv          BOOST_LIBRARYDIR     /usr/lib/x86_64-linux-gnu
 
+setenv          Boost_NO_BOOST_CMAKE     OFF
+setenv          Boost_NO_SYSTEM_PATHS    OFF
+
 conflict boost
 EOF
     exit 0
@@ -174,6 +177,9 @@ prepend-path    C_INCLUDE_PATH       ${install_dir}/include
 prepend-path    CPLUS_INCLUDE_PATH   ${install_dir}/include
 
 prepend-path    CMAKE_PREFIX_PATH    ${install_dir}
+
+setenv          Boost_NO_BOOST_CMAKE     ON
+setenv          Boost_NO_SYSTEM_PATHS    ON
 
 conflict boost
 EOF

--- a/scripts/install_petsc_hdf5.sh
+++ b/scripts/install_petsc_hdf5.sh
@@ -63,7 +63,7 @@ if [[ ("$petsc_version" = "system")
 
     mkdir -p ${base_dir}/modulefiles/petsc_hdf5/${petsc_version}_${hdf5_version}
     cd  ${base_dir}/modulefiles/petsc_hdf5/${petsc_version}_${hdf5_version}
-    cat <<EOF > ${petsc_arch}
+    cat <<EOF > linux-gnu
 #%Module1.0#####################################################################
 ###
 ## petsc_hdf5 ${petsc_version}_${hdf5_version}/${petsc_arch} modulefile
@@ -90,9 +90,6 @@ proc ModulesHelp { } {
 }
 
 module-whatis "This adds the environment variables for petsc ${petsc_version} and hdf5 ${hdf5_version}, with PETSC_ARCH=${petsc_arch}"
-
-setenv          HDF5_ROOT            /usr
-setenv          PARMETIS_ROOT        /usr
 
 conflict petsc
 conflict hdf5

--- a/scripts/install_sundials.sh
+++ b/scripts/install_sundials.sh
@@ -63,8 +63,6 @@ proc ModulesHelp { } {
 
 module-whatis "This adds the environment variables for sundials ${version}"
 
-setenv          SUNDIALS_ROOT        /usr
-
 conflict sundials
 EOF
     exit 0

--- a/scripts/install_vtk.sh
+++ b/scripts/install_vtk.sh
@@ -57,9 +57,8 @@ if [ "$version" = "system" ]; then
 ## vtk ${version} modulefile
 ##
 proc ModulesTest { } {
-    set paths "[getenv VTK_ROOT]
-               [getenv VTK_ROOT]/include/vtk-${major}.${minor}
-               [getenv VTK_ROOT]/lib"
+    set paths "/usr/include/vtk-${major}.${minor}
+               /usr/lib/x86_64-linux-gnu/libvtkCommonCore-${major}.${minor}.so"
 
     foreach path \$paths {
         if { ![file exists \$path] } {
@@ -75,8 +74,6 @@ proc ModulesHelp { } {
 }
 
 module-whatis "This adds the environment variables for vtk ${version}"
-
-setenv          VTK_ROOT             /usr
 
 conflict vtk
 EOF

--- a/scripts/install_xercesc.sh
+++ b/scripts/install_xercesc.sh
@@ -63,7 +63,6 @@ proc ModulesHelp { } {
 
 module-whatis "This adds the environment variables for xercesc ${version}"
 
-setenv          XERCESC_ROOT         /usr
 setenv          XERCESC_INCLUDE      /usr/include/xercesc
 setenv          XERCESC_LIBRARY      /usr/lib/x86_64-linux-gnu
 

--- a/scripts/install_xsd.sh
+++ b/scripts/install_xsd.sh
@@ -57,8 +57,6 @@ proc ModulesHelp { } {
 
 module-whatis "This adds the environment variables for xsd ${version}"
 
-setenv          XSD_ROOT             /usr
-
 conflict xsd
 EOF
     exit 0


### PR DESCRIPTION
**Summary**
Move boost config from workflows to modulefiles so that system images can set options `-DBoost_NO_BOOST_CMAKE` and `-DBoost_NO_SYSTEM_PATHS` to `OFF`.

**Related Issues**
* https://github.com/Chaste/Chaste/issues/197