### PR TITLE
Update boost url

### DIFF
--- a/scripts/install_boost.sh
+++ b/scripts/install_boost.sh
@@ -88,12 +88,7 @@ fi
 mkdir -p ${base_dir}/src/boost
 cd ${base_dir}/src/boost
 
-if [[ (${major} -eq 1) && (${minor} -eq 62) ]]; then  # Boost == 1.62.x
-    wget -nc https://downloads.sourceforge.net/project/boost/boost/${version}/boost_${ver_si_on}.tar.bz2
-
-else  # Boost > 1.62.x
-    wget -nc https://boostorg.jfrog.io/artifactory/main/release/${version}/source/boost_${ver_si_on}.tar.bz2
-fi
+wget -nc https://archives.boost.io/release/${version}/source/boost_${ver_si_on}.tar.bz2
 tar -xjf boost_${ver_si_on}.tar.bz2
 
 src_dir="$(pwd)/boost_${ver_si_on}"


### PR DESCRIPTION
Boost downloads have moved to https://archives.boost.io/release/